### PR TITLE
Make odd check faster

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,3 @@
-import isOdd from 'is-odd'
-
 // In order for the workers runtime to find the class that implements
 // our Durable Object namespace, we must export it from the root module.
 export { CounterTs } from './counter'
@@ -19,7 +17,7 @@ async function handleRequest(request: Request, env: Env) {
   let obj = env.COUNTER.get(id)
   let resp = await obj.fetch(request.url)
   let count = parseInt(await resp.text())
-  let wasOdd = isOdd(count) ? 'is odd' : 'is even'
+  let wasOdd = (count & 1) === 1 ? 'is odd' : 'is even'
 
   return new Response(`${count} ${wasOdd}`)
 }


### PR DESCRIPTION
Gotta save up that cpu usage, the `is-odd` package uses the unoptimized `%` operator

Note: there is still room up for optimization by removing `=== 1` but I guess that would hurt readability..