### PR TITLE
Remove DurableObjectState interface

### DIFF
--- a/src/counter.ts
+++ b/src/counter.ts
@@ -1,10 +1,3 @@
-// can be removed once https://github.com/cloudflare/workers-types/pull/106 is merged
-declare global {
-  interface DurableObjectState {
-    blockConcurrencyWhile<T>(callback: () => Promise<T>): Promise<T>
-  }
-}
-
 export class CounterTs {
   value: number = 0
   state: DurableObjectState


### PR DESCRIPTION
I haven't tested this but https://github.com/cloudflare/workers-types/pull/106 has now been merged so I assume it's safe to remove?