### PR TITLE
refactor: update wrangler.toml to conform to the current API.

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,17 +1,12 @@
 name = "worker"
-# type = "javascript" is required to use the `[build]` section
-type = "javascript"
 account_id = ""
 workers_dev = true
 route = ""
 zone_id = ""
+main = "./dist/index.mjs"
 
 [build]
 command = "npm install && npm test && npm run build"
-[build.upload]
-# The "modules" upload format is required for all projects that export a Durable Objects class
-format = "modules"
-main = "./index.mjs"
 
 [durable_objects]
 bindings = [{name = "COUNTER", class_name = "CounterTs"}]


### PR DESCRIPTION
This is quite outdated  `wrangler.toml` and the current Wrangler already spits out quite some warnings. I've updated it a bit to conform to the current Wrangler API.